### PR TITLE
Fix down() migrations

### DIFF
--- a/updates/user_add_location_fields.php
+++ b/updates/user_add_location_fields.php
@@ -21,6 +21,11 @@ class UserAddLocationFields extends Migration
 
     public function down()
     {
+        if (Schema::hasTable('users')) {
+            Schema::table('users', function ($table) {
+                $table->dropColumn(['state_id', 'country_id']);
+            });
+        }
     }
 
 }

--- a/updates/user_add_mobile_field.php
+++ b/updates/user_add_mobile_field.php
@@ -20,6 +20,11 @@ class UserAddMobileField extends Migration
 
     public function down()
     {
+        if (Schema::hasTable('users')) {
+            Schema::table('users', function ($table) {
+                $table->dropColumn(['mobile']);
+            });
+        }
     }
 
 }

--- a/updates/user_add_profile_fields.php
+++ b/updates/user_add_profile_fields.php
@@ -24,9 +24,11 @@ class UserAddProfileFields extends Migration
 
     public function down()
     {
-        Schema::table('users', function ($table) {
-            $table->dropColumn(['phone', 'company', 'street_addr', 'city', 'zip']);
-        });
+        if (Schema::hasTable('users')) {
+            Schema::table('users', function ($table) {
+                $table->dropColumn(['phone', 'company', 'street_addr', 'city', 'zip']);
+            });
+        }
     }
 
 }


### PR DESCRIPTION
Update down() functions with removing added fields, useful for plugin uninstall.

Add `Schema::hasTable('users')` condition, because when I did `php artisan october:down`, sometimes it deleted `users` table first and throws error.