### PR TITLE
wrap $widget->addTabFields($config);

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -80,7 +80,9 @@ class Plugin extends PluginBase
 
             $configFile = plugins_path('rainlab/userplus/config/profile_fields.yaml');
             $config = Yaml::parse(File::get($configFile));
-            $widget->addTabFields($config);
+            if($widget->isNested === false) {
+                $widget->addTabFields($config);
+            }
         });
     }
 


### PR DESCRIPTION
When I try to extend the User form in my Plugin.php with a repeater widget using addFields() or addTabFields() this includes all fields of the User Plus form.

Inside Plugin.php on row 73 (in the extendUsersController() function) wrap

$widget->addTabFields($config);

inside:

if($widget->isNested === false) {}

Please see my post in the forum for details:

https://octobercms.com/forum/post/extending-a-form-with-a-repeater-widget-using-addfields-or-addtabfields-includes-all-fields-of-the-parent-form?page=1#post-26331

https://github.com/rainlab/userplus-plugin/issues/30