### PR TITLE
Extending with LocationModel behavior fixed

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -59,8 +59,9 @@ class Plugin extends PluginBase
                 'city',
                 'zip'
             ]);
-
-            $model->implement[] = 'RainLab.Location.Behaviors.LocationModel';
+            if (!is_array($model->implement) || !in_array('RainLab.Location.Behaviors.LocationModel', $model->implement)) {
+                $model->implement[] = 'RainLab.Location.Behaviors.LocationModel';
+            }
 
             $model->morphMany['notifications'] = [
                 NotificationModel::class,


### PR DESCRIPTION
While running unit tests and creating the `User` model we're getting:
```
Exception: Class RainLab\User\Models\User has already been extended with RainLab\Location\Behaviors\LocationModel
```

This fix will help.